### PR TITLE
Add invisible `I` to navbar title

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,8 +1,7 @@
 <div class="navbar navbar-expand-sm navbar-dark navbar-lewagon mb-3">
   <div class="container">
     <%= link_to root_path, class: "navbar-brand" do %>
-      <%#= image_tag "icons/logo.png" %>
-      HOTW<i class="fas fa-bolt"></i>RE 101
+      HOTW<i class="fas fa-bolt"></i><span class="sr-only">I</span>RE 101
     <% end %>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
Pour rendre la navbar plus accessible pour les lecteurs d’écrans et les moteurs de recherche, on peut ajouter un `I` invisible pour écrire `HOTWIRE`.